### PR TITLE
Add dedicated spawn and finish mechanics

### DIFF
--- a/domain/map.py
+++ b/domain/map.py
@@ -24,6 +24,17 @@ class GameMap:
         self.reset_items()
 
     # ------------------------------------------------------------------
+    # Special cells
+    # ------------------------------------------------------------------
+    def spawn_cell(self) -> int:
+        """Return the dedicated spawn cell (bottom-left corner)."""
+        return self.from_rc(self.size - 1, 0)
+
+    def finish_cell(self) -> int:
+        """Return the dedicated finish cell (top-right corner)."""
+        return self.from_rc(0, self.size - 1)
+
+    # ------------------------------------------------------------------
     # Geometry helpers
     # ------------------------------------------------------------------
     @property
@@ -87,33 +98,17 @@ class GameMap:
     # ------------------------------------------------------------------
     def first_free_start_cell(self, occupied: Iterable[int]) -> int:
         occupied_set = set(occupied)
-        start = self.center_cell()
-        if start not in occupied_set:
-            return start
-
-        r0, c0 = self.to_rc(start)
-        for radius in range(1, self.size):
-            for dr in range(-radius, radius + 1):
-                for dc in range(-radius, radius + 1):
-                    r, c = r0 + dr, c0 + dc
-                    if r < 0 or r >= self.size or c < 0 or c >= self.size:
-                        continue
-                    candidate = self.from_rc(r, c)
-                    if candidate not in occupied_set:
-                        return candidate
-
-        for idx in range(1, self.total_cells + 1):
-            if idx not in occupied_set:
-                return idx
-
-        return self.center_cell()
+        # Игроки всегда появляются в одной стартовой точке, поэтому занятость
+        # остальных игроков не учитывается.
+        return self.spawn_cell()
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
     def _generate_items(self) -> Dict[int, Item]:
         total_cells = self.total_cells
-        available_cells = [cell for cell in range(1, total_cells + 1) if cell != self.center_cell()]
+        forbidden = {self.center_cell(), self.spawn_cell(), self.finish_cell()}
+        available_cells = [cell for cell in range(1, total_cells + 1) if cell not in forbidden]
         placements: Dict[int, Item] = {}
 
         for item_type, count in self._item_counts.items():

--- a/domain/player.py
+++ b/domain/player.py
@@ -23,6 +23,7 @@ class Player:
         self.cell = cell
         self.lives = lives if lives is not None else self.START_LIVES
         self._inventory: List[str] = list(inventory or [])
+        self.finished = False
 
     # ------------------------------------------------------------------
     # State helpers
@@ -45,15 +46,27 @@ class Player:
         self.cell = cell
         self.lives = lives if lives is not None else self.START_LIVES
         self._inventory.clear()
+        self.finished = False
 
     # ------------------------------------------------------------------
     # Movement
     # ------------------------------------------------------------------
-    def attempt_move(self, *, dx: int, dy: int, target_cell: int, occupied: Set[int]) -> MoveResult:
+    def attempt_move(
+        self,
+        *,
+        dx: int,
+        dy: int,
+        target_cell: int,
+        occupied: Set[int],
+        shared_cells: Optional[Set[int]] = None,
+    ) -> MoveResult:
+        if self.finished:
+            return MoveResult(success=False, reason="finished")
+
         if not self.alive:
             return MoveResult(success=False, reason="dead")
 
-        if target_cell in occupied:
+        if target_cell in occupied and (shared_cells is None or target_cell not in shared_cells):
             return MoveResult(success=False, reason="occupied")
 
         self.cell = target_cell
@@ -103,5 +116,6 @@ class Player:
             "cell": self.cell,
             "lives": self.lives,
             "alive": self.alive,
+            "finished": self.finished,
             "inventory": self.inventory_snapshot(),
         }

--- a/game_logic.py
+++ b/game_logic.py
@@ -51,6 +51,23 @@ class GameLogic:
         self.game_map = GameMap(grid_size, item_counts, rng=rng)
         self.players: Dict[str, Player] = {}
 
+    # ------------------------------------------------------------------
+    # Special cells
+    # ------------------------------------------------------------------
+    @property
+    def spawn_cell(self) -> int:
+        return self.game_map.spawn_cell()
+
+    @property
+    def finish_cell(self) -> int:
+        return self.game_map.finish_cell()
+
+    def is_spawn_cell(self, cell: int) -> bool:
+        return cell == self.spawn_cell
+
+    def is_finish_cell(self, cell: int) -> bool:
+        return cell == self.finish_cell
+
     def list_players(self) -> List[Player]:
         return list(self.players.values())
 
@@ -73,7 +90,8 @@ class GameLogic:
         for pid, player in self.players.items():
             if exclude_player_id is not None and pid == exclude_player_id:
                 continue
-            occupied.add(player.cell)
+            if not player.finished:
+                occupied.add(player.cell)
         return occupied
 
     def translate_cell(self, cell: int, dx: int, dy: int) -> int:
@@ -128,6 +146,29 @@ class GameLogic:
     def start_game(self) -> None:
         self.state.active = True
         self.state.phase = GamePhase.PLAYING
+
+    def mark_player_finished(self, player: Player) -> bool:
+        if player.finished:
+            return False
+        player.finished = True
+        return True
+
+    def all_players_resolved(self) -> bool:
+        if not self.players:
+            return False
+        for player in self.players.values():
+            if player.alive and not player.finished:
+                return False
+        return True
+
+    def finalize_if_complete(self) -> bool:
+        if not self.state.active:
+            return False
+        if not self.all_players_resolved():
+            return False
+        self.state.active = False
+        self.state.phase = GamePhase.LOBBY
+        return True
 
 
 __all__ = ["GameLogic", "GamePhase", "GameState"]

--- a/main.py
+++ b/main.py
@@ -79,6 +79,8 @@ async def send_full_state(player: Player) -> None:
     payload = {
         "t": "state",
         "n": logic.grid_size,
+        "spawn": logic.spawn_cell,
+        "finish": logic.finish_cell,
         "revealed": list(logic.revealed_snapshot()),
         "player": player.to_public(),
         "items": [
@@ -102,6 +104,7 @@ async def broadcast_player_snapshot(player: Player) -> None:
             "cell": player.cell,
             "lives": player.lives,
             "alive": player.alive,
+            "finished": player.finished,
         }
     )
 
@@ -130,6 +133,15 @@ async def broadcast_game_status(state: str, *, by: Optional[str] = None) -> None
     await broadcast_json(payload)
 
 
+async def broadcast_player_finish(player: Player) -> None:
+    await broadcast_json({"t": "finish", "id": player.id, "cell": player.cell})
+
+
+async def finalize_game_if_needed(*, trigger: Optional[Player] = None) -> None:
+    if logic.finalize_if_complete():
+        await broadcast_game_status("completed", by=trigger.id if trigger else None)
+
+
 async def apply_life_change(player: Player, amount: int) -> bool:
     """Применяет изменение жизней и сообщает об этом."""
     died = logic.adjust_player_lives(player, amount)
@@ -139,25 +151,29 @@ async def apply_life_change(player: Player, amount: int) -> bool:
     return died
 
 
-async def handle_cell_item(player: Player) -> None:
+async def handle_cell_item(player: Player) -> bool:
     """Применяет эффект предмета на текущей клетке (если есть)."""
     resolved = logic.resolve_cell_item(player)
     if not resolved:
-        return
+        return False
 
     item, result = resolved
     payload = {"t": "item", "cell": player.cell, "item": item.item_type.value, "by": player.id}
     await broadcast_json(payload)
 
+    died = False
     if result.affects_lives:
         await broadcast_player_snapshot(player)
         if result.died:
             await broadcast_json({"t": "death", "id": player.id, "cell": player.cell})
+            died = True
 
     if result.inventory_changed:
         ws = get_player_ws(player)
         if ws is not None:
             await send_json(ws, {"t": "inventory", "items": player.inventory_snapshot()})
+
+    return died
 
 
 def occupied_cells(*, except_ws: Optional[WebSocket] = None) -> Set[int]:
@@ -225,7 +241,12 @@ async def ws_endpoint(websocket: WebSocket) -> None:
     await broadcast_players_list()
 
     if logic.state.active and player.alive:
-        await handle_cell_item(player)
+        died = await handle_cell_item(player)
+        if died:
+            await finalize_game_if_needed(trigger=player)
+        elif player.finished:
+            await broadcast_players_list()
+            await broadcast_player_finish(player)
 
     try:
         while True:
@@ -252,6 +273,7 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                     dy=dy,
                     target_cell=target_cell,
                     occupied=occupied_cells(except_ws=websocket),
+                    shared_cells={logic.spawn_cell},
                 )
 
                 if not move_result.success:
@@ -262,6 +284,10 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                 if logic.mark_revealed(player.cell):
                     newly.append(player.cell)
 
+                finished_now = False
+                if logic.is_finish_cell(player.cell):
+                    finished_now = logic.mark_player_finished(player)
+
                 await broadcast_player_snapshot(player)
 
                 if newly:
@@ -270,17 +296,33 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                     if player.alive and logic.should_trigger_hazard():
                         died = await apply_life_change(player, logic.hazard_damage)
                         if died:
+                            await finalize_game_if_needed(trigger=player)
                             continue
 
                 if player.alive:
-                    await handle_cell_item(player)
+                    if finished_now:
+                        await broadcast_player_finish(player)
+                        await broadcast_players_list()
+                        await finalize_game_if_needed(trigger=player)
+                        continue
+                    died_from_item = await handle_cell_item(player)
+                    if died_from_item:
+                        await finalize_game_if_needed(trigger=player)
+                        continue
+                    if player.finished:
+                        await broadcast_players_list()
+                        await broadcast_player_finish(player)
+                        await finalize_game_if_needed(trigger=player)
+                        continue
 
             elif mtype == "damage":
                 if not logic.state.active:
                     await notify_game_inactive(websocket)
                     continue
                 amount = int(msg.get("amount", 0))
-                await apply_life_change(player, amount)
+                died = await apply_life_change(player, amount)
+                if died:
+                    await finalize_game_if_needed(trigger=player)
 
             elif mtype == "pickup":
                 if not logic.state.active:
@@ -313,7 +355,13 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                     await broadcast_player_snapshot(pl)
                 for pl in logic.list_players():
                     if pl.alive:
-                        await handle_cell_item(pl)
+                        died_from_item = await handle_cell_item(pl)
+                        if died_from_item:
+                            await finalize_game_if_needed(trigger=pl)
+                        elif pl.finished:
+                            await broadcast_players_list()
+                            await broadcast_player_finish(pl)
+                await finalize_game_if_needed(trigger=player)
 
             elif mtype == "restart":
                 await perform_restart(player)


### PR DESCRIPTION
## Summary
- add explicit spawn and finish cells to the map and expose them through the game logic
- let players share the spawn cell, track finish state, and conclude the game when everyone is done or dead
- update the server to broadcast spawn/finish info, handle finish events, and avoid placing items on special cells

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e6028305288322b8bb2dfe2fddcd41