### PR TITLE
Add turn-based movement with random step counts

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -20,11 +20,19 @@ class GameState:
             cls._instance = super().__new__(cls)
             cls._instance.active = False
             cls._instance.phase = GamePhase.LOBBY
+            cls._instance.turn_order = []
+            cls._instance.current_turn_index = -1
+            cls._instance.current_turn_player_id: Optional[str] = None
+            cls._instance.steps_remaining = 0
         return cls._instance
 
     def reset(self) -> None:
         self.active = False
         self.phase = GamePhase.LOBBY
+        self.turn_order = []
+        self.current_turn_index = -1
+        self.current_turn_player_id = None
+        self.steps_remaining = 0
 
 
 class GameLogic:
@@ -80,6 +88,8 @@ class GameLogic:
 
     def remove_player(self, player_id: str) -> Optional[Player]:
         player = self.players.pop(player_id, None)
+        if player is not None:
+            self.handle_player_inactive(player)
         return player
 
     def get_player(self, player_id: str) -> Optional[Player]:
@@ -146,6 +156,90 @@ class GameLogic:
     def start_game(self) -> None:
         self.state.active = True
         self.state.phase = GamePhase.PLAYING
+        self.state.turn_order = []
+        self.state.current_turn_index = -1
+        self.state.current_turn_player_id = None
+        self.state.steps_remaining = 0
+
+    # ------------------------------------------------------------------
+    # Turn management
+    # ------------------------------------------------------------------
+    def roll_turn_length(self) -> int:
+        return int(self.rng.randint(1, 4))
+
+    def start_turn_cycle(self) -> Optional[Player]:
+        self.state.turn_order = [
+            player.id for player in self.players.values() if player.alive and not player.finished
+        ]
+        self.state.current_turn_index = -1
+        self.state.current_turn_player_id = None
+        self.state.steps_remaining = 0
+        if not self.state.turn_order:
+            return None
+        return self._advance_to_next_turn()
+
+    def _advance_to_next_turn(self) -> Optional[Player]:
+        if not self.state.turn_order:
+            self.state.current_turn_index = -1
+            self.state.current_turn_player_id = None
+            self.state.steps_remaining = 0
+            return None
+
+        for _ in range(len(self.state.turn_order)):
+            self.state.current_turn_index = (self.state.current_turn_index + 1) % len(self.state.turn_order)
+            player_id = self.state.turn_order[self.state.current_turn_index]
+            player = self.players.get(player_id)
+            if player and player.alive and not player.finished:
+                self.state.current_turn_player_id = player_id
+                self.state.steps_remaining = self.roll_turn_length()
+                return player
+
+        self.state.current_turn_index = -1
+        self.state.current_turn_player_id = None
+        self.state.steps_remaining = 0
+        return None
+
+    def consume_step(self, player: Player, *, force_end: bool = False, spend: bool = True) -> Optional[Player]:
+        if self.state.current_turn_player_id != player.id:
+            return None
+
+        if spend and self.state.steps_remaining > 0:
+            self.state.steps_remaining -= 1
+
+        if force_end:
+            self.state.steps_remaining = 0
+
+        if self.state.steps_remaining <= 0:
+            return self._advance_to_next_turn()
+
+        return player
+
+    def is_player_turn(self, player: Player) -> bool:
+        return self.state.current_turn_player_id == player.id
+
+    def handle_player_inactive(self, player: Player) -> None:
+        player_id = player.id
+        if player_id not in self.state.turn_order:
+            return
+
+        idx = self.state.turn_order.index(player_id)
+        self.state.turn_order.pop(idx)
+
+        if idx < self.state.current_turn_index:
+            self.state.current_turn_index -= 1
+        elif idx == self.state.current_turn_index:
+            self.state.current_turn_index -= 1
+            self.state.current_turn_player_id = None
+            self.state.steps_remaining = 0
+            if self.state.active:
+                self._advance_to_next_turn()
+
+    def turn_snapshot(self) -> Dict[str, object]:
+        return {
+            "current": self.state.current_turn_player_id,
+            "remaining": self.state.steps_remaining,
+            "order": list(self.state.turn_order),
+        }
 
     def mark_player_finished(self, player: Player) -> bool:
         if player.finished:
@@ -168,6 +262,10 @@ class GameLogic:
             return False
         self.state.active = False
         self.state.phase = GamePhase.LOBBY
+        self.state.turn_order = []
+        self.state.current_turn_index = -1
+        self.state.current_turn_player_id = None
+        self.state.steps_remaining = 0
         return True
 
 

--- a/main.py
+++ b/main.py
@@ -91,6 +91,7 @@ async def send_full_state(player: Player) -> None:
         "game_phase": logic.state.phase.value,
         "joinable": logic.state.phase is GamePhase.LOBBY,
         "players": [p.to_public() for p in logic.list_players()],
+        "turn": logic.turn_snapshot(),
     }
     await send_json(ws, payload)
 
@@ -137,9 +138,14 @@ async def broadcast_player_finish(player: Player) -> None:
     await broadcast_json({"t": "finish", "id": player.id, "cell": player.cell})
 
 
+async def broadcast_turn_info() -> None:
+    await broadcast_json({"t": "turn", **logic.turn_snapshot()})
+
+
 async def finalize_game_if_needed(*, trigger: Optional[Player] = None) -> None:
     if logic.finalize_if_complete():
         await broadcast_game_status("completed", by=trigger.id if trigger else None)
+        await broadcast_turn_info()
 
 
 async def apply_life_change(player: Player, amount: int) -> bool:
@@ -204,6 +210,7 @@ async def perform_restart(requester: Optional[Player] = None) -> None:
     await broadcast_players_list()
 
     await broadcast_game_status("ready", by=requester.id if requester else None)
+    await broadcast_turn_info()
 
 
 # ===================== WebSocket =====================
@@ -264,6 +271,20 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                     await notify_game_inactive(websocket)
                     continue
 
+                if not logic.is_player_turn(player):
+                    await send_json(
+                        websocket,
+                        {"t": "error", "code": "not_your_turn", "reason": "not_your_turn"},
+                    )
+                    continue
+
+                async def conclude_move(force_end: bool, *, remove_from_turn: bool) -> None:
+                    if logic.state.active:
+                        logic.consume_step(player, force_end=force_end)
+                    if remove_from_turn:
+                        logic.handle_player_inactive(player)
+                    await broadcast_turn_info()
+
                 dx = int(msg.get("dx", 0))
                 dy = int(msg.get("dy", 0))
 
@@ -296,6 +317,7 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                     if player.alive and logic.should_trigger_hazard():
                         died = await apply_life_change(player, logic.hazard_damage)
                         if died:
+                            await conclude_move(force_end=True, remove_from_turn=True)
                             await finalize_game_if_needed(trigger=player)
                             continue
 
@@ -303,17 +325,22 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                     if finished_now:
                         await broadcast_player_finish(player)
                         await broadcast_players_list()
+                        await conclude_move(force_end=True, remove_from_turn=True)
                         await finalize_game_if_needed(trigger=player)
                         continue
                     died_from_item = await handle_cell_item(player)
                     if died_from_item:
+                        await conclude_move(force_end=True, remove_from_turn=True)
                         await finalize_game_if_needed(trigger=player)
                         continue
                     if player.finished:
                         await broadcast_players_list()
                         await broadcast_player_finish(player)
+                        await conclude_move(force_end=True, remove_from_turn=True)
                         await finalize_game_if_needed(trigger=player)
                         continue
+
+                await conclude_move(force_end=False, remove_from_turn=False)
 
             elif mtype == "damage":
                 if not logic.state.active:
@@ -322,6 +349,10 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                 amount = int(msg.get("amount", 0))
                 died = await apply_life_change(player, amount)
                 if died:
+                    if logic.state.active and logic.is_player_turn(player):
+                        logic.consume_step(player, force_end=True, spend=False)
+                    logic.handle_player_inactive(player)
+                    await broadcast_turn_info()
                     await finalize_game_if_needed(trigger=player)
 
             elif mtype == "pickup":
@@ -361,6 +392,9 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                         elif pl.finished:
                             await broadcast_players_list()
                             await broadcast_player_finish(pl)
+                if logic.state.active:
+                    logic.start_turn_cycle()
+                await broadcast_turn_info()
                 await finalize_game_if_needed(trigger=player)
 
             elif mtype == "restart":
@@ -374,3 +408,4 @@ async def ws_endpoint(websocket: WebSocket) -> None:
             logic.remove_player(stored_player.id)
             player_connections.pop(stored_player.id, None)
             await broadcast_players_list()
+            await broadcast_turn_info()


### PR DESCRIPTION
## Summary
- add turn-tracking fields and helpers to the game logic so each turn rolls a random 1-4 step allowance
- enforce per-turn movement limits in the websocket handler, broadcasting turn updates and rejecting out-of-turn moves
- surface turn information to clients in state snapshots and keep it in sync on restart or disconnect

## Testing
- python -m py_compile game_logic.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68e60455c98083228df04dfeb3bbcb57