### PR TITLE
Refine finish unlock item handling

### DIFF
--- a/domain/item.py
+++ b/domain/item.py
@@ -14,6 +14,8 @@ class ItemType(str, Enum):
     ZOMBIE = "zombie"
     MEDKIT = "medkit"
     WEAPON = "weapon"
+    KEY = "key"
+    FUEL = "fuel"
 
     @classmethod
     def from_string(cls, value: str) -> "ItemType":
@@ -52,7 +54,7 @@ class Item:
         if self.item_type is ItemType.MEDKIT:
             healed = player.heal(MEDKIT_HEAL)
             return ItemResolution(healed=healed, died=not player.alive)
-        if self.item_type is ItemType.WEAPON:
-            player.add_item("weapon")
-            return ItemResolution(inventory_added="weapon", died=not player.alive)
+        if self.item_type in (ItemType.WEAPON, ItemType.KEY, ItemType.FUEL):
+            collected = player.collect_item(self.item_type)
+            return ItemResolution(inventory_added=collected, died=not player.alive)
         raise ValueError(f"Unsupported item type: {self.item_type}")

--- a/domain/player.py
+++ b/domain/player.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Set, Tuple
+from typing import Iterable, List, Optional, Set, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .item import ItemType
 
 
 @dataclass(frozen=True)
@@ -96,6 +99,16 @@ class Player:
     # ------------------------------------------------------------------
     def add_item(self, item: str) -> None:
         self._inventory.append(item)
+
+    def collect_item(self, item_type: "ItemType") -> Optional[str]:
+        """Collects a map item and stores it in the inventory if supported."""
+
+        item_value = getattr(item_type, "value", str(item_type))
+        if item_value not in {"weapon", "key", "fuel"}:
+            return None
+
+        self.add_item(item_value)
+        return item_value
 
     def remove_item(self, item: str) -> bool:
         try:

--- a/game_logic.py
+++ b/game_logic.py
@@ -1,5 +1,6 @@
 import random
 from enum import Enum
+from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from domain import GameMap, Item, ItemResolution, ItemType, Player
@@ -8,6 +9,13 @@ from domain import GameMap, Item, ItemResolution, ItemType, Player
 class GamePhase(str, Enum):
     LOBBY = "lobby"
     PLAYING = "playing"
+
+
+@dataclass(frozen=True)
+class PlayerFinishResult:
+    finished: bool
+    inventory_changed: bool = False
+    reason: Optional[str] = None
 
 
 class GameState:
@@ -58,6 +66,8 @@ class GameLogic:
         self.state = GameState()
         self.game_map = GameMap(grid_size, item_counts, rng=rng)
         self.players: Dict[str, Player] = {}
+        self.door_unlocked = False
+        self.finish_required_items: Tuple[str, ...] = ("key", "fuel")
 
     # ------------------------------------------------------------------
     # Special cells
@@ -142,6 +152,7 @@ class GameLogic:
 
     def restart_game(self) -> List[Player]:
         self.game_map.reset()
+        self.door_unlocked = False
 
         occupied: Set[int] = set()
         for player in sorted(self.players.values(), key=lambda p: p.id):
@@ -154,6 +165,7 @@ class GameLogic:
         return list(self.players.values())
 
     def start_game(self) -> None:
+        self.door_unlocked = False
         self.state.active = True
         self.state.phase = GamePhase.PLAYING
         self.state.turn_order = []
@@ -241,11 +253,28 @@ class GameLogic:
             "order": list(self.state.turn_order),
         }
 
-    def mark_player_finished(self, player: Player) -> bool:
+    def can_player_finish(self, player: Player) -> bool:
+        if self.door_unlocked:
+            return True
+        inventory = set(player.inventory)
+        return all(item in inventory for item in self.finish_required_items)
+
+    def mark_player_finished(self, player: Player) -> PlayerFinishResult:
         if player.finished:
-            return False
+            return PlayerFinishResult(finished=False, reason="already_finished")
+
+        if not self.can_player_finish(player):
+            return PlayerFinishResult(finished=False, reason="missing_items")
+
+        inventory_changed = False
+        if not self.door_unlocked:
+            for item in self.finish_required_items:
+                removed = player.remove_item(item)
+                inventory_changed = inventory_changed or removed
+            self.door_unlocked = True
+
         player.finished = True
-        return True
+        return PlayerFinishResult(finished=True, inventory_changed=inventory_changed)
 
     def all_players_resolved(self) -> bool:
         if not self.players:
@@ -269,4 +298,4 @@ class GameLogic:
         return True
 
 
-__all__ = ["GameLogic", "GamePhase", "GameState"]
+__all__ = ["PlayerFinishResult", "GameLogic", "GamePhase", "GameState"]

--- a/main.py
+++ b/main.py
@@ -17,6 +17,8 @@ ITEM_COUNTS = {
     ItemType.ZOMBIE: 3,
     ItemType.MEDKIT: 2,
     ItemType.WEAPON: 2,
+    ItemType.KEY: 1,
+    ItemType.FUEL: 1,
 }
 
 # --- Новые параметры автосмерти/опасности ---
@@ -307,7 +309,21 @@ async def ws_endpoint(websocket: WebSocket) -> None:
 
                 finished_now = False
                 if logic.is_finish_cell(player.cell):
-                    finished_now = logic.mark_player_finished(player)
+                    finish_result = logic.mark_player_finished(player)
+                    finished_now = finish_result.finished
+                    if finish_result.inventory_changed:
+                        await send_json(
+                            websocket, {"t": "inventory", "items": player.inventory_snapshot()}
+                        )
+                    if finish_result.reason and not finish_result.finished:
+                        await send_json(
+                            websocket,
+                            {
+                                "t": "error",
+                                "code": finish_result.reason,
+                                "reason": finish_result.reason,
+                            },
+                        )
 
                 await broadcast_player_snapshot(player)
 


### PR DESCRIPTION
## Summary
- centralize collectible item handling in the player entity and reuse it for key and fuel pickups
- rename the finish resolution dataclass to PlayerFinishResult for clarity around its usage

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e66efb251c8322919a0df94ac6b0b6