### PR TITLE
Handle zombie encounters with displacement

### DIFF
--- a/domain/item.py
+++ b/domain/item.py
@@ -34,6 +34,7 @@ class ItemResolution:
     inventory_added: Optional[str] = None
     inventory_removed: Optional[str] = None
     died: bool = False
+    relocated_to: Optional[int] = None
 
     @property
     def affects_lives(self) -> bool:

--- a/domain/map.py
+++ b/domain/map.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import random
+from collections import deque
 from typing import Dict, Iterable, Iterator, Optional, Sequence, Set, Tuple
 
 from .item import Item, ItemType
@@ -61,6 +62,13 @@ class GameMap:
         mid = self.size // 2
         return self.from_rc(mid, mid)
 
+    def _neighbors(self, cell: int) -> Iterable[int]:
+        r, c = self.to_rc(cell)
+        for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+            nr, nc = r + dr, c + dc
+            if 0 <= nr < self.size and 0 <= nc < self.size:
+                yield self.from_rc(nr, nc)
+
     # ------------------------------------------------------------------
     # Items & revealed cells
     # ------------------------------------------------------------------
@@ -92,6 +100,29 @@ class GameMap:
 
     def place_item(self, cell: int, item: Item) -> None:
         self._items[cell] = item
+
+    def nearest_revealed_cell(
+        self,
+        start: int,
+        *,
+        exclude: Optional[Set[int]] = None,
+        occupied: Optional[Set[int]] = None,
+    ) -> Optional[int]:
+        exclude_set = set(exclude) if exclude else set()
+        occupied_set = set(occupied) if occupied else set()
+        visited: Set[int] = set()
+        queue = deque([start])
+        visited.add(start)
+
+        while queue:
+            cell = queue.popleft()
+            if cell in self._revealed and cell not in exclude_set and cell not in occupied_set:
+                return cell
+            for neighbor in self._neighbors(cell):
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    queue.append(neighbor)
+        return None
 
     # ------------------------------------------------------------------
     # Spawn helpers

--- a/game_logic.py
+++ b/game_logic.py
@@ -1,6 +1,6 @@
 import random
 from enum import Enum
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from domain import GameMap, Item, ItemResolution, ItemType, Player
@@ -143,11 +143,27 @@ class GameLogic:
             player.heal(-amount)
         return died
 
-    def resolve_cell_item(self, player: Player) -> Optional[Tuple[Item, ItemResolution]]:
+    def resolve_cell_item(
+        self,
+        player: Player,
+        *,
+        occupied: Optional[Set[int]] = None,
+    ) -> Optional[Tuple[Item, ItemResolution]]:
         item = self.game_map.take_item(player.cell)
         if not item:
             return None
         result = item.apply(player)
+        if item.item_type is ItemType.ZOMBIE:
+            if result.damage > 0 and not result.inventory_removed and not result.died:
+                occupied_cells = set(occupied) if occupied is not None else self.occupied_cells(exclude_player_id=player.id)
+                target = self.game_map.nearest_revealed_cell(
+                    player.cell,
+                    exclude={player.cell},
+                    occupied=occupied_cells,
+                )
+                if target is not None:
+                    player.cell = target
+                    result = replace(result, relocated_to=target)
         return item, result
 
     def restart_game(self) -> List[Player]:

--- a/main.py
+++ b/main.py
@@ -161,16 +161,20 @@ async def apply_life_change(player: Player, amount: int) -> bool:
 
 async def handle_cell_item(player: Player) -> bool:
     """Применяет эффект предмета на текущей клетке (если есть)."""
-    resolved = logic.resolve_cell_item(player)
+    origin_cell = player.cell
+    resolved = logic.resolve_cell_item(
+        player,
+        occupied=logic.occupied_cells(exclude_player_id=player.id),
+    )
     if not resolved:
         return False
 
     item, result = resolved
-    payload = {"t": "item", "cell": player.cell, "item": item.item_type.value, "by": player.id}
+    payload = {"t": "item", "cell": origin_cell, "item": item.item_type.value, "by": player.id}
     await broadcast_json(payload)
 
     died = False
-    if result.affects_lives:
+    if result.affects_lives or result.relocated_to is not None:
         await broadcast_player_snapshot(player)
         if result.died:
             await broadcast_json({"t": "death", "id": player.id, "cell": player.cell})


### PR DESCRIPTION
## Summary
- extend item resolution and game logic to relocate players to the nearest revealed tile when an unarmed zombie encounter deals damage
- add map search helpers for revealed cells and ensure server notifications use the original tile for zombie item events

## Testing
- python -m compileall domain/item.py domain/map.py game_logic.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68e67c94bfdc83229ae1d368d3f1644c