### PR TITLE
Add start and restart controls to Unity client

### DIFF
--- a/client/zombie_client/Assets/Scripts/NetClient.cs
+++ b/client/zombie_client/Assets/Scripts/NetClient.cs
@@ -6,6 +6,7 @@ using NativeWebSocket;
 
 // ---- модели сообщений ----
 [System.Serializable] public class MoveMsg { public string t = "move"; public int dx; public int dy; }
+[System.Serializable] public class CommandMsg { public string t; }
 [System.Serializable] public class PlayerStateMsg { public string t; public int cell; }
 [System.Serializable] public class RevealMsg { public string t; public int[] cells; }
 [System.Serializable] public class StateMsg
@@ -57,6 +58,20 @@ public class NetClient : MonoBehaviour
         var json = JsonUtility.ToJson(new MoveMsg { dx = dx, dy = dy });
         await ws.SendText(json);
         Debug.Log($"Sent move: {json}");
+    }
+
+    public void SendStartCommand() => SendCommand("start");
+
+    public void SendRestartCommand() => SendCommand("restart");
+
+    private async void SendCommand(string commandType)
+    {
+        if (string.IsNullOrEmpty(commandType)) return;
+        if (ws == null || ws.State != WebSocketState.Open) return;
+
+        var json = JsonUtility.ToJson(new CommandMsg { t = commandType });
+        await ws.SendText(json);
+        Debug.Log($"Sent command: {json}");
     }
 
     // --- обработка входящих ---

--- a/client/zombie_client/Assets/Scripts/PlayerInput.cs
+++ b/client/zombie_client/Assets/Scripts/PlayerInput.cs
@@ -6,6 +6,9 @@ public class PlayerInput : MonoBehaviour
 {
     [SerializeField] private NetClient net;  // ← ссылка на NetClient
 
+    [SerializeField] private Rect startButtonRect = new Rect(16f, 16f, 160f, 36f);
+    [SerializeField] private Rect restartButtonRect = new Rect(16f, 60f, 160f, 36f);
+
     private void Update()
     {
         if (net == null) return;
@@ -17,5 +20,19 @@ public class PlayerInput : MonoBehaviour
         if (kb.rightArrowKey.wasPressedThisFrame || kb.dKey.wasPressedThisFrame) net.SendPlayerDelta(+1, 0);
         if (kb.upArrowKey.wasPressedThisFrame    || kb.wKey.wasPressedThisFrame) net.SendPlayerDelta( 0,-1);
         if (kb.downArrowKey.wasPressedThisFrame  || kb.sKey.wasPressedThisFrame) net.SendPlayerDelta( 0,+1);
+
+        if (kb.gKey.wasPressedThisFrame) net.SendStartCommand();
+        if (kb.pKey.wasPressedThisFrame) net.SendRestartCommand();
+    }
+
+    private void OnGUI()
+    {
+        if (net == null) return;
+
+        if (GUI.Button(startButtonRect, "Start (G)"))
+            net.SendStartCommand();
+
+        if (GUI.Button(restartButtonRect, "Restart (P)"))
+            net.SendRestartCommand();
     }
 }


### PR DESCRIPTION
## Summary
- add immediate-mode start and restart buttons in the client
- wire keyboard shortcuts (G and P) to trigger start and restart commands
- extend the network client with helpers to send start and restart requests

## Testing
- not run (Unity environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68e7e81ae73883228eb11f65bbbe3f53