### PR TITLE
Add inventory HUD display

### DIFF
--- a/client/zombie_client/Assets/Scenes/SampleScene.unity
+++ b/client/zombie_client/Assets/Scenes/SampleScene.unity
@@ -626,6 +626,218 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 657030907}
   m_CullTransparentMesh: 1
+--- !u!1 &2100000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100000001}
+  - component: {fileID: 2100000002}
+  - component: {fileID: 2100000003}
+  m_Layer: 5
+  m_Name: InventoryBlock
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2100000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2100000005}
+  m_Father: {fileID: 1987708447}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20, y: -20}
+  m_SizeDelta: {x: 260, y: 140}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &2100000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_CullTransparentMesh: 1
+--- !u!114 &2100000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.39215687}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2100000004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100000005}
+  - component: {fileID: 2100000006}
+  - component: {fileID: 2100000007}
+  m_Layer: 5
+  m_Name: InventoryText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2100000005
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000004}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2100000001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2100000006
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000004}
+  m_CullTransparentMesh: 1
+--- !u!114 &2100000007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u0418\u043d\u0432\u0435\u043d\u0442\u0430\u0440\u044c:\n\u2022 \u041e\u0440\u0443\u0436\u0438\u0435: 0\n\u2022 \u041a\u043b\u044e\u0447: 0\n\u2022 \u0422\u043e\u043f\u043b\u0438\u0432\u043e: 0"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 28
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1040562444
 GameObject:
   m_ObjectHideFlags: 0
@@ -794,6 +1006,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::NetClient
   serverUrl: ws://127.0.0.1:8000/ws
   timerText: {fileID: 657030909}
+  inventoryText: {fileID: 2100000007}
   board: {fileID: 1040562451}
 --- !u!4 &1498377170
 Transform:
@@ -1000,6 +1213,7 @@ RectTransform:
   - {fileID: 1040562446}
   - {fileID: 484320603}
   - {fileID: 606610354}
+  - {fileID: 2100000001}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/client/zombie_client/Assets/Scripts/NetClient.cs
+++ b/client/zombie_client/Assets/Scripts/NetClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
 using TMPro;
@@ -7,24 +8,50 @@ using NativeWebSocket;
 // ---- модели сообщений ----
 [System.Serializable] public class MoveMsg { public string t = "move"; public int dx; public int dy; }
 [System.Serializable] public class CommandMsg { public string t; }
-[System.Serializable] public class PlayerStateMsg { public string t; public int cell; }
+[System.Serializable] public class PlayerStateMsg
+{
+    public string t;
+    public string id;
+    public int cell;
+    public int lives;
+    public bool alive;
+    public bool finished;
+}
 [System.Serializable] public class RevealMsg { public string t; public int[] cells; }
+[System.Serializable] public class InventoryMsg { public string t; public string[] items; }
+[System.Serializable] public class PlayerPublicMsg
+{
+    public string id;
+    public int cell;
+    public int lives;
+    public bool alive;
+    public bool finished;
+    public string[] inventory;
+}
 [System.Serializable] public class StateMsg
 {
     public string t;
     public int n;               // размер поля
     public int[] revealed;      // открытые клетки
-    public PlayerStateMsg player;
+    public PlayerPublicMsg player;
 }
 
 public class NetClient : MonoBehaviour
 {
     [SerializeField] private string serverUrl = "ws://127.0.0.1:8000/ws";
     [SerializeField] private TextMeshProUGUI timerText;
+    [SerializeField] private TextMeshProUGUI inventoryText;
     [SerializeField] private BoardUIDynamic board;   // динамическая доска
 
     private WebSocket ws;
     private readonly ConcurrentQueue<string> _inbox = new();
+
+    private readonly (string key, string label)[] _knownInventoryItems =
+    {
+        ("weapon", "Оружие"),
+        ("key", "Ключ"),
+        ("fuel", "Топливо"),
+    };
 
     // --- подключение ---
     private async void Start()
@@ -94,7 +121,10 @@ public class NetClient : MonoBehaviour
                     if (st.revealed != null && st.revealed.Length > 0)
                         board.RevealCells(st.revealed);
                     if (st.player != null)
+                    {
                         board.MovePlayerToCell(st.player.cell);
+                        UpdateInventoryDisplay(st.player.inventory);
+                    }
                     continue;
                 }
 
@@ -113,12 +143,61 @@ public class NetClient : MonoBehaviour
                     board.RevealCells(rv.cells);
                     continue;
                 }
+
+                // инвентарь игрока
+                var inv = JsonUtility.FromJson<InventoryMsg>(msg);
+                if (inv != null && inv.t == "inventory")
+                {
+                    UpdateInventoryDisplay(inv.items);
+                    continue;
+                }
             }
 
             // иначе — число бота
             if (int.TryParse(msg, out var cell))
                 board.MoveBotToCell(cell);
         }
+    }
+
+    private void UpdateInventoryDisplay(IList<string> items)
+    {
+        if (inventoryText == null) return;
+
+        var counts = new Dictionary<string, int>();
+        if (items != null)
+        {
+            foreach (var item in items)
+            {
+                if (string.IsNullOrEmpty(item)) continue;
+                if (!counts.ContainsKey(item)) counts[item] = 0;
+                counts[item]++;
+            }
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("Инвентарь:");
+
+        foreach (var (key, label) in _knownInventoryItems)
+        {
+            counts.TryGetValue(key, out var value);
+            counts.Remove(key);
+            sb.Append("• ")
+              .Append(label)
+              .Append(": ")
+              .Append(value)
+              .AppendLine();
+        }
+
+        foreach (var pair in counts)
+        {
+            sb.Append("• ")
+              .Append(pair.Key)
+              .Append(": ")
+              .Append(pair.Value)
+              .AppendLine();
+        }
+
+        inventoryText.text = sb.ToString().TrimEnd('\n');
     }
 
     private async void OnApplicationQuit()


### PR DESCRIPTION
## Summary
- add an inventory text panel to the canvas so the client UI always shows the player's resources
- extend the websocket client logic to parse inventory updates from the server and refresh the HUD counters

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e7e9d6115883229f00f4c275eb167d