### PR TITLE
Reset board covers before applying new state

### DIFF
--- a/client/zombie_client/Assets/Scripts/NetClient.cs
+++ b/client/zombie_client/Assets/Scripts/NetClient.cs
@@ -120,6 +120,7 @@ public class NetClient : MonoBehaviour
                 if (st != null && st.t == "state")
                 {
                     if (st.n > 0) board.SetSize(st.n);
+                    board.HideAllCovers();
                     if (st.revealed != null && st.revealed.Length > 0)
                         board.RevealCells(st.revealed);
                     if (st.player != null)


### PR DESCRIPTION
## Summary
- reset the board UI covers before applying a new state payload so restarted games start with closed cells

## Testing
- not run (unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e7f076cd7883229af39b63abc32ab8