### PR TITLE
Remove bot references from client UI logic

### DIFF
--- a/client/zombie_client/Assets/Scripts/BoardUI.cs
+++ b/client/zombie_client/Assets/Scripts/BoardUI.cs
@@ -4,11 +4,9 @@ using UnityEngine;
 public class BoardUI : MonoBehaviour
 {
     [Header("Tokens")]
-    [SerializeField] private RectTransform botToken;     // фишка бота (с сервера)
     [SerializeField] private RectTransform playerToken;  // фишка игрока (локально)
 
     private readonly List<RectTransform> _cells = new(); // Cell1..Cell9 (по порядку)
-    private int _botCell = 5;      // текущее положение бота (1..9)
     private int _playerCell = 5;   // текущее положение игрока (1..9)
 
     private void Awake()
@@ -20,7 +18,7 @@ public class BoardUI : MonoBehaviour
             if (child == null) continue;
 
             // собираем только клетки (исключаем токены, если они уже лежат внутри Board)
-            if (child == botToken || child == playerToken) continue;
+            if (child == playerToken) continue;
             _cells.Add(child);
         }
 
@@ -28,19 +26,10 @@ public class BoardUI : MonoBehaviour
             Debug.LogWarning($"BoardUI: найдено {_cells.Count} клеток, ожидается 9.");
 
         // стартовые позиции по центру (клетка 5)
-        MoveTokenToCell(botToken, _botCell);
         MoveTokenToCell(playerToken, _playerCell);
     }
 
     // ========== Публичные методы ==========
-
-    /// <summary>Движение бота по номеру клетки 1..9 (из сервера).</summary>
-    public void MoveBotToCell(int cellNumber)
-    {
-        _botCell = ClampCell(cellNumber);
-        MoveTokenToCell(botToken, _botCell);
-    }
-
     /// <summary>Переместить игрока в конкретную клетку 1..9 (если захочешь клики).</summary>
     public void MovePlayerToCell(int cellNumber)
     {

--- a/client/zombie_client/Assets/Scripts/BoardUIDynamic.cs
+++ b/client/zombie_client/Assets/Scripts/BoardUIDynamic.cs
@@ -13,7 +13,6 @@ public class BoardUIDynamic : MonoBehaviour
     [SerializeField] private Color coverColor = new(0f,0f,0f,0.55f); // цвет «крышки»
 
     [Header("Tokens")]
-    [SerializeField] private RectTransform botToken;
     [SerializeField] private RectTransform playerToken;
     [SerializeField] private Vector2 tokenSize = new(80,80);
 
@@ -21,7 +20,7 @@ public class BoardUIDynamic : MonoBehaviour
     private readonly List<Image> _covers = new();              // полупрозрачные крышки над клетками
     private GridLayoutGroup _grid;
     private RectTransform _rt;
-    private int _playerCell=1, _botCell=1;
+    private int _playerCell = 1;
 
     private void Awake()
     {
@@ -34,9 +33,7 @@ public class BoardUIDynamic : MonoBehaviour
         BuildGrid(gridSize);
 
         _playerCell = Mathf.Clamp((gridSize*gridSize+1)/2,1,gridSize*gridSize);
-        _botCell = 1;
         MoveTokenToCell(playerToken, _playerCell);
-        MoveTokenToCell(botToken, _botCell);
     }
 
     // -------- API --------
@@ -47,12 +44,9 @@ public class BoardUIDynamic : MonoBehaviour
         gridSize = n;
         BuildGrid(n);
         _playerCell = Mathf.Clamp(_playerCell,1,n*n);
-        _botCell = Mathf.Clamp(_botCell,1,n*n);
         MoveTokenToCell(playerToken,_playerCell);
-        MoveTokenToCell(botToken,_botCell);
     }
 
-    public void MoveBotToCell(int idx1)    { _botCell    = ClampIndex(idx1);    MoveTokenToCell(botToken,_botCell); }
     public void MovePlayerToCell(int idx1) { _playerCell = ClampIndex(idx1);    MoveTokenToCell(playerToken,_playerCell); }
 
     public void RevealCell(int idx1)
@@ -109,7 +103,6 @@ public class BoardUIDynamic : MonoBehaviour
             _covers.Add(coverImg);
         }
 
-        botToken?.SetAsLastSibling();
         playerToken?.SetAsLastSibling();
     }
 

--- a/client/zombie_client/Assets/Scripts/NetClient.cs
+++ b/client/zombie_client/Assets/Scripts/NetClient.cs
@@ -159,9 +159,6 @@ public class NetClient : MonoBehaviour
                 }
             }
 
-            // иначе — число бота
-            if (int.TryParse(msg, out var cell))
-                board.MoveBotToCell(cell);
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the obsolete bot token field and state from the board UI scripts
- stop the net client from expecting standalone bot cell updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7f296f6d48322a196199c2ab5209f