### PR TITLE
Ensure zombies persist after non-lethal encounters

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -149,7 +149,8 @@ class GameLogic:
         *,
         occupied: Optional[Set[int]] = None,
     ) -> Optional[Tuple[Item, ItemResolution]]:
-        item = self.game_map.take_item(player.cell)
+        original_cell = player.cell
+        item = self.game_map.take_item(original_cell)
         if not item:
             return None
         result = item.apply(player)
@@ -164,6 +165,9 @@ class GameLogic:
                 if target is not None:
                     player.cell = target
                     result = replace(result, relocated_to=target)
+            zombie_defeated = bool(result.inventory_removed) or result.died
+            if not zombie_defeated:
+                self.game_map.place_item(original_cell, item)
         return item, result
 
     def restart_game(self) -> List[Player]:


### PR DESCRIPTION
## Summary
- keep track of the original cell when resolving encounters
- return zombies to their cell when they are not defeated so they can attack again

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7f40feea48322abc43b3ca8134de3